### PR TITLE
fix: Tuning max.poll.records.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,4 @@ make clean
 | [0.3.0](https://github.com/cbdq-io/sbus-integration-test/pull/10) | 128,000      | PT51M48S  |  41.2 |
 | [0.4.0](https://github.com/cbdq-io/sbus-integration-test/pull/12) | 128,000      | PT46M12S  |  46.2 |
 | [0.5.0](https://github.com/cbdq-io/sbus-integration-test/pull/16) | 128,000      | PT19M17S  | 110.7 |
+| [0.5.1](https://github.com/cbdq-io/sbus-integration-test/pull/18) | 128,000      | PT20M32S  | 103.9 |

--- a/terraform/azure/modules/azure/main.tf
+++ b/terraform/azure/modules/azure/main.tf
@@ -205,6 +205,7 @@ resource "azurerm_container_group" "kafka_connect" {
       CONNECTOR_AzureServiceBusSink_ERRORS_LOG_ENABLE                                       = "true"
       CONNECTOR_AzureServiceBusSink_ERRORS_LOG_INCLUDE_MESSAGES                             = "true"
       CONNECTOR_AzureServiceBusSink_ERRORS_TOLERANCE                                        = "all"
+      CONNECTOR_AzureServiceBusSink_MAX_POLL_RECORDS                                        = "1000"
       CONNECTOR_AzureServiceBusSink_RETRY_MAX_ATTEMPTS                                      = "5"
       CONNECTOR_AzureServiceBusSink_RETRY_WAIT_TIME_MS                                      = "1000"
       CONNECTOR_AzureServiceBusSink_SET_KAFKA_PARTITION_AS_SESSION_ID                       = "true"

--- a/terraform/azure/modules/azure/main.tf
+++ b/terraform/azure/modules/azure/main.tf
@@ -205,7 +205,7 @@ resource "azurerm_container_group" "kafka_connect" {
       CONNECTOR_AzureServiceBusSink_ERRORS_LOG_ENABLE                                       = "true"
       CONNECTOR_AzureServiceBusSink_ERRORS_LOG_INCLUDE_MESSAGES                             = "true"
       CONNECTOR_AzureServiceBusSink_ERRORS_TOLERANCE                                        = "all"
-      CONNECTOR_AzureServiceBusSink_MAX_POLL_RECORDS                                        = "1000"
+      CONNECTOR_AzureServiceBusSink_CONSUMER_OVERRIDE_MAX_POLL_RECORDS                      = "1000"
       CONNECTOR_AzureServiceBusSink_RETRY_MAX_ATTEMPTS                                      = "5"
       CONNECTOR_AzureServiceBusSink_RETRY_WAIT_TIME_MS                                      = "1000"
       CONNECTOR_AzureServiceBusSink_SET_KAFKA_PARTITION_AS_SESSION_ID                       = "true"

--- a/terraform/azure/modules/azure/variables.tf
+++ b/terraform/azure/modules/azure/variables.tf
@@ -11,7 +11,7 @@ variable "kafka_password" {
 
 variable "kc_image" {
   description = "The Kafka Connect image and tag."
-  default     = "ghcr.io/cbdq-io/kc-connectors:0.3.1"
+  default     = "ghcr.io/cbdq-io/kc-connectors:0.3.3"
   type        = string
 }
 


### PR DESCRIPTION
Increased the batch size of messages from 500 to 1000, but this did not increase performance as the duration was still PT20M32S, which is a TPS of 103.9.