### PR TITLE
Migrate data_gen.py to use Confluent.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ azure-core==1.32.0
 azure-servicebus==7.13.0
 certifi==2024.12.14
 charset-normalizer==3.4.1
+confluent-kafka==2.10.0
 cramjam==2.9.1
 idna==3.10
 isodate==0.7.2


### PR DESCRIPTION
This PR fixes #24.  It improves performance through a number of improvements, but the most significant is migrating the Kafka client library to [Confluent](https://docs.confluent.io/kafka-clients/python/current/overview.html).  This uses the underlying [librdkafka](https://github.com/edenhill/librdkafka) library (must be installed on the machine generating the data).  We can know load 128,000 messages in under 40 seconds (we achieved a TPS of 3,415 as opposed to 434 with the Apache Kafka client).  It possibly makes sense to increase the message count from 128,000 to 1,000,000?