### PR TITLE
feat: Test the sending of large (>1MB) messages.

### DIFF
--- a/terraform/azure/modules/azure/main.tf
+++ b/terraform/azure/modules/azure/main.tf
@@ -22,7 +22,7 @@ resource "azurerm_servicebus_topic" "sbt_landing" {
 
   name                          = "landing.topic.${count.index}"
   namespace_id                  = azurerm_servicebus_namespace.sbns.id
-  max_message_size_in_kilobytes = null
+  max_message_size_in_kilobytes = 4096
   partitioning_enabled          = false
 }
 
@@ -46,9 +46,10 @@ resource "azurerm_servicebus_subscription" "sbts_archivist" {
 resource "azurerm_servicebus_topic" "sbt" {
   count = var.topic_count
 
-  name                 = "routed.topic.${count.index}"
-  namespace_id         = azurerm_servicebus_namespace.sbns.id
-  partitioning_enabled = false
+  name                          = "routed.topic.${count.index}"
+  max_message_size_in_kilobytes = 4096
+  namespace_id                  = azurerm_servicebus_namespace.sbns.id
+  partitioning_enabled          = false
 }
 
 resource "azurerm_servicebus_subscription" "client" {

--- a/terraform/azure/modules/azure/variables.tf
+++ b/terraform/azure/modules/azure/variables.tf
@@ -17,7 +17,7 @@ variable "kafka_password" {
 
 variable "kc_image" {
   description = "The Kafka Connect image and tag."
-  default     = "ghcr.io/cbdq-io/kc-connectors:0.4.1"
+  default     = "ghcr.io/cbdq-io/kc-connectors:latest"
   type        = string
 }
 

--- a/terraform/kafka/main.tf
+++ b/terraform/kafka/main.tf
@@ -100,9 +100,11 @@ resource "kubernetes_manifest" "kafka_sbox" {
           "queued.max.requests"                      = 5000
           "transaction.state.log.min.isr"            = 1
           "transaction.state.log.replication.factor" = 2
-          "replica.fetch.max.bytes"                  = 1048576
+          "replica.fetch.max.bytes"                  = 4194352
           "num.replica.fetchers"                     = 4
           "log.retention.hours"                      = 6
+          "message.max.bytes"                        = 4194352
+          "socket.request.max.bytes"                 = 5242880
         }
         "listeners" = [
           {
@@ -250,6 +252,9 @@ resource "kubernetes_manifest" "kafkatopic_topics" {
       "namespace" = var.ns_name
     }
     "spec" = {
+      "config" = {
+        "max.message.bytes" = "4096000"
+      }
       "partitions" = 8
       "replicas"   = 2
     }


### PR DESCRIPTION
Configures the Kakfa and Service Bus topics to be able to handle messages up to 4MB.